### PR TITLE
Feature/cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ fabric.properties
 !.idea/runConfigurations
 
 # End of https://www.toptal.com/developers/gitignore/api/go,goland,goland+all
+
+vendor/

--- a/flow/persist/db_flow_manager.go
+++ b/flow/persist/db_flow_manager.go
@@ -369,6 +369,7 @@ func (fm *DBFlowManager) convertTriggerProcessorModelToSimpleTriggerProcessor(mo
 		Config:       model.Configuration,
 		LogLevel:     model.LogLevel,
 		Enabled:      model.Enabled,
+		SingleNode:   model.SingleNode,
 	}
 }
 
@@ -396,6 +397,7 @@ func (fm *DBFlowManager) convertSimpleTriggerProcessorToTriggerProcessorModel(tr
 		CronExpr:      triggerProcessor.CronExpr,
 		Configuration: triggerProcessor.Config,
 		LogLevel:      triggerProcessor.LogLevel,
+		SingleNode:    triggerProcessor.SingleNode,
 		Enabled:       triggerProcessor.Enabled,
 	}
 }

--- a/flow/persist/trigger_processor_model.go
+++ b/flow/persist/trigger_processor_model.go
@@ -9,13 +9,14 @@ import (
 type triggerProcessorModel struct {
 	ID            uuid.UUID              `gorm:"type:uuid;primaryKey"`
 	FlowID        uuid.UUID              `gorm:"column:flow_id;type:uuid;not null;index"`
-	Name          string                 `gorm:"type:varchar(255);not null"`               // Name of the trigger processor
-	Type          string                 `gorm:"type:varchar(255);not null"`               // Type of the trigger processor
-	LogLevel      logrus.Level           `gorm:"column:log_level;not null;default:'info'"` // Logging level for this trigger processor
-	Configuration map[string]interface{} `gorm:"column:configuration;type:jsonb;not null"` // Configuration for the trigger processor
-	ScheduleType  int                    `gorm:"column:schedule_type;not null;default:0"`  // 0 for EventDriven, 1 for CronDriven
-	CronExpr      string                 `gorm:"type:varchar(255)"`                        // Cron expression for CronDriven trigger processors
-	Enabled       bool                   `gorm:"column:enabled;not null;default:true"`     // Indicates if the trigger processor is enabled
+	Name          string                 `gorm:"type:varchar(255);not null"`                // Name of the trigger processor
+	Type          string                 `gorm:"type:varchar(255);not null"`                // Type of the trigger processor
+	LogLevel      logrus.Level           `gorm:"column:log_level;not null;default:'info'"`  // Logging level for this trigger processor
+	Configuration map[string]interface{} `gorm:"column:configuration;type:jsonb;not null"`  // Configuration for the trigger processor
+	ScheduleType  int                    `gorm:"column:schedule_type;not null;default:0"`   // 0 for EventDriven, 1 for CronDriven
+	CronExpr      string                 `gorm:"type:varchar(255)"`                         // Cron expression for CronDriven trigger processors
+	SingleNode    bool                   `gorm:"column:single_node;not null;default:false"` // Indicates if the trigger processor should run on a single node
+	Enabled       bool                   `gorm:"column:enabled;not null;default:true"`      // Indicates if the trigger processor is enabled
 }
 
 // BeforeCreate hook to generate a UUID if not provided.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/eko/gocache/lib/v4 v4.1.6
 	github.com/eko/gocache/store/ristretto/v4 v4.2.2
-	github.com/go-streamline/interfaces v0.1.0
+	github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50
+	github.com/go-zookeeper/zk v1.0.4
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/eko/gocache/lib/v4 v4.1.6
 	github.com/eko/gocache/store/ristretto/v4 v4.2.2
-	github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50
+	github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/eko/gocache/lib/v4 v4.1.6
 	github.com/eko/gocache/store/ristretto/v4 v4.2.2
-	github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0
+	github.com/go-streamline/interfaces v0.1.1
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50 h1:SLtHMZ0qCsGrHvZolE5iXuxIyAhGSlLbjMnNQIRnZYE=
-github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
+github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0 h1:uapAS6aKTr2KjGluETyNYH4lQ96cOkzFQdEOEqhgj4k=
+github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
 github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=
 github.com/go-zookeeper/zk v1.0.4/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0 h1:uapAS6aKTr2KjGluETyNYH4lQ96cOkzFQdEOEqhgj4k=
-github.com/go-streamline/interfaces v0.1.1-0.20241024100241-8057c4e693f0/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
+github.com/go-streamline/interfaces v0.1.1 h1:3cpxwHRCppJdRdS0X6minqz6ZdgGJxbkmln6M8H680k=
+github.com/go-streamline/interfaces v0.1.1/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
 github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=
 github.com/go-zookeeper/zk v1.0.4/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,10 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-streamline/interfaces v0.1.0 h1:b05U9qsQLrVdZPGcbprz9bCyI0yO4a6lgPUSk62kZBU=
-github.com/go-streamline/interfaces v0.1.0/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
+github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50 h1:SLtHMZ0qCsGrHvZolE5iXuxIyAhGSlLbjMnNQIRnZYE=
+github.com/go-streamline/interfaces v0.1.1-0.20241018103956-08c9ba7ddb50/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
+github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=
+github.com/go-zookeeper/zk v1.0.4/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/zookeeper/coordinator.go
+++ b/zookeeper/coordinator.go
@@ -1,0 +1,256 @@
+package zookeeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+	"path"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/go-zookeeper/zk"
+	"github.com/sirupsen/logrus"
+)
+
+// coordinator is an implementation of the Coordinator interface using Zookeeper for leader election.
+// It assigns leaders for each trigger processor using round-robin so all nodes get an equal chance to be the leader.
+// It also monitors the nodes in the cluster and triggers rebalancing when nodes change.
+// If current node is the coordinator, it assigns a leader for the trigger processor and updates the znode.
+// If current node is not the coordinator, it watches the znode for the trigger processor to check if it is the leader.
+type coordinator struct {
+	leaderSelector definitions.LeaderSelector // LeaderSelector to determine if the current node is the coordinator
+	conn           *zk.Conn                   // Zookeeper connection
+	tpLeaderPath   string                     // Path where the leader nodes for each TP are stored
+	tpLeaders      map[uuid.UUID]string       // Map of trigger processors and their assigned leaders (tpID -> leaderNode)
+	roundRobinIdx  int                        // Index for round-robin leader selection
+	mu             sync.Mutex                 // Mutex to protect tpLeaders
+	log            *logrus.Logger
+	ctx            context.Context
+	cancel         context.CancelFunc
+	nodes          []string // Cached list of nodes in the cluster
+
+}
+
+// NewCoordinator creates a new Coordinator instance.
+func NewCoordinator(leaderSelector definitions.LeaderSelector, conn *zk.Conn, tpLeaderPath string, log *logrus.Logger) definitions.Coordinator {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &coordinator{
+		leaderSelector: leaderSelector,
+		conn:           conn,
+		tpLeaderPath:   path.Dir(tpLeaderPath),
+		tpLeaders:      make(map[uuid.UUID]string),
+		log:            log,
+		ctx:            ctx,
+		cancel:         cancel,
+		nodes:          []string{},
+	}
+
+	// Start monitoring nodes in the cluster
+	go c.monitorNodeChanges()
+
+	return c
+}
+
+// IsLeader checks if the current node is the leader for the given trigger processor (tpID).
+// If the node is the coordinator, it assigns a leader and updates the znode for the TP.
+// If the node is not the coordinator, it monitors the znode for the TP to check if it is the leader.
+func (c *coordinator) IsLeader(tpID uuid.UUID) (bool, error) {
+	isCoordinator, err := c.leaderSelector.IsLeader()
+	if err != nil {
+		return false, err
+	}
+
+	if isCoordinator {
+		// This node is the coordinator, assign a leader for the TP if not already assigned
+		return c.getOrAssignLeader(tpID)
+	}
+
+	// This node is not the coordinator, watch the znode for changes
+	return c.watchZNode(tpID)
+}
+
+// getOrAssignLeader retrieves or assigns a leader for the trigger processor (tpID).
+// It updates the znode for the TP with the chosen leader if not already assigned.
+func (c *coordinator) getOrAssignLeader(tpID uuid.UUID) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if the leader is already assigned for this TP
+	if leader, exists := c.tpLeaders[tpID]; exists {
+		return leader == c.leaderSelector.ParticipantName(), nil
+	}
+
+	leaderNode, err := c.assignNewLeaderNode(tpID)
+
+	if err != nil {
+		return false, err
+	}
+
+	// Check if the current node is the leader
+	return leaderNode == c.leaderSelector.ParticipantName(), nil
+}
+
+func (c *coordinator) assignNewLeaderNode(tpID uuid.UUID) (string, error) {
+	if (len(c.nodes)) == 0 {
+		return "", fmt.Errorf("no nodes available for leader selection")
+	}
+
+	// Round-robin leader selection
+	leaderNode := c.nodes[c.roundRobinIdx]
+	c.roundRobinIdx = (c.roundRobinIdx + 1) % len(c.nodes)
+
+	// Update the tpLeaders map and the Zookeeper znode for this TP
+	c.tpLeaders[tpID] = leaderNode
+	err := c.updateZNode(tpID, leaderNode)
+
+	return leaderNode, err
+}
+
+// watchZNode watches the znode for the given trigger processor (tpID).
+// It checks if the current node is the leader by monitoring the znode data.
+func (c *coordinator) watchZNode(tpID uuid.UUID) (bool, error) {
+	// Watch the znode for changes
+	path := fmt.Sprintf("%s/%s", c.tpLeaderPath, tpID)
+	data, _, err := c.conn.Get(path)
+	if err != nil {
+		if errors.Is(err, zk.ErrNoNode) {
+			c.log.Warnf("znode for tpID %s does not exist, retrying election...", tpID)
+			return false, nil
+		}
+		return false, err
+	}
+
+	leaderNode := string(data)
+	if leaderNode == c.leaderSelector.ParticipantName() {
+		// This node is the leader for the TP
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// monitorNodeChanges uses the leaderSelector to subscribe to node change events and trigger rebalancing when necessary.
+func (c *coordinator) monitorNodeChanges() {
+	nodeChangeCh := c.leaderSelector.ParticipantsChangeChannel()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-nodeChangeCh:
+			c.mu.Lock()
+			nodes, err := c.leaderSelector.Participants()
+			if err != nil {
+				c.log.WithError(err).Error("failed to retrieve nodes for monitoring after event")
+				c.mu.Unlock()
+				continue
+			}
+
+			if !equalNodeLists(nodes, c.nodes) {
+				c.log.Infof("nodes changed, triggering rebalancing... old: %v, new: %v", c.nodes, nodes)
+				c.nodes = nodes
+				// Trigger rebalancing if nodes change
+				c.mu.Unlock()
+				c.rebalanceLeadership()
+			} else {
+				c.mu.Unlock()
+			}
+		}
+	}
+}
+
+// rebalanceLeadership reassigns trigger processor leadership when nodes change.
+func (c *coordinator) rebalanceLeadership() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for {
+		// Check if the current node is still the coordinator
+		isLeader, err := c.leaderSelector.IsLeader()
+		if err != nil {
+			c.log.WithError(err).Error("failed to check leader status during rebalancing")
+			time.Sleep(5 * time.Second) // Backoff before retrying
+			continue
+		}
+
+		if !isLeader {
+			c.log.Info("node is no longer the leader, stopping rebalancing")
+			return // Exit the loop if the node is no longer the coordinator
+		}
+
+		// Perform the rebalancing if still the leader
+		err = c.attemptRebalance()
+		if err != nil {
+			c.log.WithError(err).Error("rebalancing failed, retrying...")
+			time.Sleep(5 * time.Second) // Backoff before retrying
+			continue
+		}
+
+		// If rebalancing is successful, break out of the loop
+		break
+	}
+}
+
+// attemptRebalance performs the actual rebalancing logic
+func (c *coordinator) attemptRebalance() error {
+	nodes := c.nodes
+	if len(nodes) == 0 {
+		return fmt.Errorf("no nodes available for rebalancing")
+	}
+
+	// Reassign leaders in round-robin fashion based on updated node list
+	for tpID := range c.tpLeaders {
+		_, err := c.assignNewLeaderNode(tpID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateZNode updates the leader znode for a trigger processor
+func (c *coordinator) updateZNode(tpID uuid.UUID, leaderNode string) error {
+	znode := fmt.Sprintf("%s/%s", c.tpLeaderPath, tpID)
+
+	// check if exists first
+	exists, _, err := c.conn.Exists(znode)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		_, _, err = CreateFullPath(c.conn, znode, []byte(leaderNode), zk.FlagEphemeral)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err = c.conn.Set(znode, []byte(leaderNode), -1)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close stops the coordinator by canceling the context and stopping any leader selection.
+func (c *coordinator) Close() error {
+	c.cancel()
+	return nil
+}
+
+// equalNodeLists checks if two lists of nodes are equal
+func equalNodeLists(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if !slices.Contains(a, b[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/zookeeper/leader_selector.go
+++ b/zookeeper/leader_selector.go
@@ -1,0 +1,264 @@
+package zookeeper
+
+import (
+	"context"
+	"errors"
+	"github.com/go-streamline/interfaces/definitions"
+	"sync"
+	"time"
+
+	"github.com/go-zookeeper/zk"
+	"github.com/sirupsen/logrus"
+)
+
+type leaderSelector struct {
+	conn             *zk.Conn
+	znodePath        string
+	nodeName         string // Store the created node name
+	currentLeader    string // Hostname of the current leader
+	isLeader         bool
+	leaderMutex      sync.Mutex
+	electLeaderMutex sync.Mutex
+	log              *logrus.Logger
+	ctx              context.Context
+	cancel           context.CancelFunc
+	nodeChangeCh     chan []string // Channel to notify about node changes
+}
+
+// NewZookeeperLeaderSelector creates a new instance of the leader selector for Zookeeper.
+func NewZookeeperLeaderSelector(conn *zk.Conn, znodePath string, log *logrus.Logger) definitions.LeaderSelector {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &leaderSelector{
+		conn:         conn,
+		znodePath:    znodePath,
+		log:          log,
+		ctx:          ctx,
+		cancel:       cancel,
+		nodeChangeCh: make(chan []string, 1),
+	}
+}
+
+// NodeName returns the name of the leader node.
+func (z *leaderSelector) NodeName() string {
+	return z.currentLeader
+}
+
+// NodeChangeChannel returns a channel that can be used to receive node change notifications.
+func (z *leaderSelector) NodeChangeChannel() <-chan []string {
+	return z.nodeChangeCh
+}
+
+// Start attempts to elect the node as a leader or monitor the current leader.
+func (z *leaderSelector) Start() error {
+	z.log.Infof("starting leader election on znode %s", z.znodePath)
+
+	go z.monitorNodeChanges()
+	go z.monitorConnection()
+	_, err := z.tryElectLeader()
+
+	return err
+}
+
+func (z *leaderSelector) Nodes() ([]string, error) {
+	children, _, err := z.conn.Children(z.znodePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []string
+	for _, child := range children {
+		if len(child) >= len("leader_") && child[:len("leader_")] == "leader_" {
+			data, _, err := z.conn.Get(z.znodePath + "/" + child)
+			if err != nil {
+				z.log.WithError(err).Errorf("failed to retrieve data for child %s", child)
+				continue
+			}
+			nodes = append(nodes, string(data))
+		}
+	}
+
+	return nodes, nil
+}
+
+// IsLeader checks if the current node is the leader in the given zNode path.
+// If the node is not a leader, it will monitor the leader status.
+func (z *leaderSelector) IsLeader() (bool, error) {
+	z.leaderMutex.Lock()
+	defer z.leaderMutex.Unlock()
+	return z.isLeader, nil
+}
+
+// Close stops the leader selector by canceling the context.
+func (z *leaderSelector) Close() error {
+	z.cancel()
+	z.log.Infof("stopping leader selector")
+	return nil
+}
+
+// createZnode creates the znode for leader election.
+func (z *leaderSelector) createZnode() error {
+	flags := int32(zk.FlagEphemeralSequential)
+	path := z.znodePath + "/leader_"
+	createdPath, err := CreateFullPath(z.conn, path, nil, flags)
+	if err != nil {
+		z.log.WithError(err).Error("failed to create znode for leader election")
+		return err
+	}
+	z.nodeName = createdPath
+	return nil
+}
+
+// Internal function that attempts to elect the node as a leader.
+func (z *leaderSelector) tryElectLeader() (bool, error) {
+	z.electLeaderMutex.Lock()
+	defer z.electLeaderMutex.Unlock()
+
+	if z.nodeName == "" {
+		err := z.createZnode()
+		if err != nil {
+			return false, err
+		}
+	} else {
+		exists, _, err := z.conn.Exists(z.nodeName)
+		if err != nil {
+			z.log.WithError(err).Error("failed to check existence of znode")
+			return false, err
+		}
+		if !exists {
+			z.log.Warnf("znode not found, attempting to create a new znode")
+			err = z.createZnode()
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+
+	children, _, err := z.conn.Children(z.znodePath)
+	if err != nil {
+		z.log.WithError(err).Error("failed to retrieve children for leader election")
+		return false, err
+	}
+
+	// Filter and sort the children to find the minimum node with the correct prefix
+	var eligibleChildren []string
+	for _, child := range children {
+		if len(child) >= len("leader_") && child[:len("leader_")] == "leader_" {
+			eligibleChildren = append(eligibleChildren, child)
+		}
+	}
+
+	if len(eligibleChildren) == 0 {
+		return false, errors.New("no eligible leader nodes found")
+	}
+
+	minNode := eligibleChildren[0]
+	for _, child := range eligibleChildren {
+		if child < minNode {
+			minNode = child
+		}
+	}
+
+	minNodePath := z.znodePath + "/" + minNode
+	data, _, err := z.conn.Get(minNodePath)
+	if err != nil {
+		z.log.WithError(err).Error("failed to get data for current leader")
+		return false, err
+	}
+
+	z.currentLeader = string(data)
+
+	if minNodePath == z.nodeName {
+		z.updateLeaderStatus(true)
+		z.log.Infof("node %s has acquired leadership", z.nodeName)
+		return true, nil
+	}
+
+	z.updateLeaderStatus(false)
+	return false, nil
+}
+
+// Internal function that monitors node changes and notifies through the nodeChangeCh.
+func (z *leaderSelector) monitorNodeChanges() {
+	for {
+		children, _, ch, err := z.conn.ChildrenW(z.znodePath)
+		if err != nil {
+			z.log.WithError(err).Error("error occurred while monitoring node changes")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		var nodes []string
+		for _, child := range children {
+			if len(child) >= len("leader_") && child[:len("leader_")] == "leader_" {
+				data, _, err := z.conn.Get(z.znodePath + "/" + child)
+				if err != nil {
+					z.log.WithError(err).Errorf("failed to retrieve data for child %s", child)
+					continue
+				}
+				nodes = append(nodes, string(data))
+			}
+		}
+
+		select {
+		case event := <-ch:
+			if event.Type == zk.EventNodeChildrenChanged || event.Type == zk.EventNodeDeleted {
+				z.log.Info("nodes changed or deleted, notifying through nodeChangeCh")
+				select {
+				case z.nodeChangeCh <- nodes:
+					// Successfully sent notification
+				default:
+					// Channel is full, dropping notification to avoid infinite loop
+					z.log.Warn("nodeChangeCh is full, dropping notification to prevent infinite loop")
+				}
+				// Re-check leadership status after nodes change
+				_, _ = z.tryElectLeader()
+			}
+		case <-z.ctx.Done():
+			return
+		}
+	}
+}
+
+// Internal function to handle the transition of leadership.
+// When a node is elected or loses leadership, this function will update the leader status.
+func (z *leaderSelector) updateLeaderStatus(isLeader bool) {
+	z.leaderMutex.Lock()
+	defer z.leaderMutex.Unlock()
+	if z.isLeader != isLeader {
+		z.isLeader = isLeader
+		if isLeader {
+			z.log.Infof("has become the leader.")
+		} else {
+			z.log.Infof("is no longer the leader.")
+		}
+	}
+}
+
+// monitorConnection monitors the connection to Zookeeper and ensures that leadership is lost if the connection is disconnected.
+// When reconnected, it attempts to reacquire leadership.
+func (z *leaderSelector) monitorConnection() {
+	for {
+		select {
+		case <-z.ctx.Done():
+			z.log.Info("stop signal received, exiting connection monitoring loop.")
+			return
+		default:
+			// Check if the connection is still valid
+			state := z.conn.State()
+			if state == zk.StateDisconnected || state == zk.StateExpired || state == zk.StateConnecting {
+				z.log.Warn("disconnected from Zookeeper, losing leadership status")
+				z.updateLeaderStatus(false)
+
+				// Wait until the connection is re-established
+				for state == zk.StateDisconnected {
+					time.Sleep(5 * time.Second)
+					state = z.conn.State()
+				}
+
+				z.log.Info("reconnected to Zookeeper, attempting to reacquire leadership")
+				_, _ = z.tryElectLeader()
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+}

--- a/zookeeper/utils.go
+++ b/zookeeper/utils.go
@@ -1,0 +1,51 @@
+package zookeeper
+
+import (
+	"errors"
+	"github.com/go-zookeeper/zk"
+	"os"
+	"strings"
+)
+
+func CreateFullPath(conn *zk.Conn, path string, data []byte, flags int32) (string, error) {
+	parts := splitPath(path)
+	// drop last part
+	parts = parts[:len(parts)-1]
+	currentPath := ""
+	for _, part := range parts {
+		currentPath += "/" + part
+		exists, _, err := conn.Exists(currentPath)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			_, err = conn.Create(currentPath, []byte{}, 0, zk.WorldACL(zk.PermAll))
+			if err != nil && !errors.Is(err, zk.ErrNodeExists) {
+				return "", err
+			}
+		}
+	}
+
+	if data == nil {
+		host, err := os.Hostname()
+		if err != nil {
+			return "", err
+		}
+
+		data = []byte(host)
+	}
+	return conn.Create(path, data, flags, zk.WorldACL(zk.PermAll))
+}
+
+func splitPath(path string) []string {
+	parts := strings.Split(path, "/")
+
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+
+	return nonEmptyParts
+}


### PR DESCRIPTION
Added zookeeper based coordinator & leader selector. Added support for SingleNode in db flow manager too.

Tested the new coordinator & leader selector using this docker-compose:
```yaml
version: '3'
services:
  zookeeper:
    image: zookeeper:3.7.2
    ports:
      - "2181:2181"
    container_name: zookeeper
    environment:
        ZOO_MY_ID: 1
        ZOO_SERVERS: server.1=zookeeper:2888:3888;2181

  core0:
    image: core:latest
    container_name: core0

  core1:
    image: core:latest
    container_name: core1

  core2:
    image: core:latest
    container_name: core2
  core3:
    image: core:latest
    container_name: core3
```

this docker file:
```Dockerfile
FROM golang:1.23.2-alpine3.20 AS builder

WORKDIR /app
COPY . .
RUN go mod tidy
RUN go build -o /app/main .


FROM alpine:3.13
COPY --from=builder /app/main /app/main
CMD ["/app/main", "zookeeper:2181"]
```


and this main.go:
```go
package main

import (
	"context"
	"github.com/go-streamline/core/zookeeper"
	"github.com/go-zookeeper/zk"
	"github.com/google/uuid"
	"github.com/sirupsen/logrus"
	"os"
	"os/signal"
	"time"
)

var uuids = []string{
	"8670d592-756b-49bd-bd7c-2ff8fdd5305c",
	"2968e141-8175-466f-a08c-fc11b4e2c492",
	"fcabe1a2-270f-4866-9046-005a3c090c69",
	"6487e965-ac10-4807-903f-cd81af40b222",
	"c77f4f39-e57c-4489-9b96-bed1a8b7992f",
	"8ca53bb2-40b6-4994-ba20-5078969d41d2",
	"dda612d0-9ecd-45a6-976a-cddde1e58ddc",
	"15259a5a-3b86-4e03-b39e-02ba01e6cc6a",
	"85d4989f-e39f-4286-ac6c-ac096b77f818",
	"9e4e17d7-7c78-4523-b2f9-2cedda4a7778",
}

type HostHook struct {
	Hostname string
	Context  string
}

func (hook *HostHook) Levels() []logrus.Level {
	return logrus.AllLevels
}

func (hook *HostHook) Fire(entry *logrus.Entry) error {
	entry.Data["host"] = hook.Hostname
	entry.Data["context"] = hook.Context
	return nil
}

func main() {

	s := os.Args[1]
	logrus.Infof("Connecting to %s", s)
	conn, _, err := zk.Connect([]string{s}, 10*time.Second)
	if err != nil {
		panic(err)
	}
	hostname, err := os.Hostname()
	if err != nil {
		panic(err)
	}
	zkLogger := logrus.New()
	zkLogger.AddHook(&HostHook{Hostname: hostname, Context: "zkLeader"})
	leader := zookeeper.NewZookeeperLeaderSelector(conn, "/whatever/nodes", zkLogger, "myleader_")
	leader.Start()

	time.Sleep(2 * time.Second)
	nodes, err := leader.Nodes()
	if err != nil {
		logrus.Errorf("Error getting nodes: %v", err)
	}
	logrus.Infof("nodes: %s", nodes)

	ctx, cancel := context.WithCancel(context.Background())

	zkLogger = logrus.New()
	zkLogger.AddHook(&HostHook{Hostname: hostname, Context: "zkCoordinator"})
	coordinator := zookeeper.NewCoordinator(leader, conn, "/whatever/aaaa/", zkLogger)
	logrus.AddHook(&HostHook{Hostname: hostname, Context: "main"})
	go func() {
		t := time.NewTicker(5 * time.Second)
		for {
			select {
			case <-t.C:
				isLeader, err := leader.IsLeader()
				if err != nil {
					logrus.WithField("host", hostname).Errorf("Error checking if leader: %v", err)
					continue
				}
				logrus.Infof("Is leader: %v", isLeader)
				for _, u := range uuids {
					isLeader, err = coordinator.IsLeader(uuid.MustParse(u))
					if err != nil {
						logrus.Errorf("Error checking if tp is leader: %v", err)
						continue
					}
					logrus.Infof("Is leader for %s: %v", u, isLeader)
				}
			case <-ctx.Done():
				t.Stop()
				return
			}
		}
	}()

	signals := make(chan os.Signal, 1)
	signal.Notify(signals, os.Interrupt)
	<-signals
	cancel()

}
```

I've tested the following:
* delete leader znode and check that it creates it back and no longer marked the leader(while the new node gets assigned as leader) while no rebalance occurs(since the list of participants stay the same).
* take leader znode down and check the next node is marked as leader, also check that a rebalance occurred and the new coordinator split the leaderships equally
* take down zookeeper and then back up and check that no one's the leader while zk is down. Check that the new leader checks the list of participants and changes nothing if all nodes got to create their znode in time. Check that it rebalances if not all nodes made it and then rebalances again when all nodes get registered as participants.
* take down a non leader participant and check that rebalance occurred.
* add a participant and check that rebalance occurs and now all nodes have equally split the leaderships.

