### PR TITLE
added state managers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/eko/gocache/lib/v4 v4.1.6
 	github.com/eko/gocache/store/ristretto/v4 v4.2.2
-	github.com/go-streamline/interfaces v0.1.1
+	github.com/go-streamline/interfaces v0.1.3
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-streamline/interfaces v0.1.1 h1:3cpxwHRCppJdRdS0X6minqz6ZdgGJxbkmln6M8H680k=
-github.com/go-streamline/interfaces v0.1.1/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
+github.com/go-streamline/interfaces v0.1.3 h1:Pl1tpfnilQ0nwmVyDZ3mkjvaQEnPF6bnbXVqB0Wqmoc=
+github.com/go-streamline/interfaces v0.1.3/go.mod h1:fkb3uJI4B2+3dcWUoCww0fSaWjIMiYfFkmxBhsoSyZg=
 github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=
 github.com/go-zookeeper/zk v1.0.4/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/state/local_state_manager.go
+++ b/state/local_state_manager.go
@@ -1,0 +1,187 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"os"
+	"path"
+	"time"
+)
+
+var (
+	ErrCouldNotCreateDirectory = fmt.Errorf("could not create state directory")
+	ErrCouldNotOpenFile        = fmt.Errorf("could not open state file")
+	ErrCouldNotReadFile        = fmt.Errorf("could not read state file")
+	ErrFileCorrupted           = fmt.Errorf("state file corrupted, could not unmarshal")
+	ErrCouldNotWriteFile       = fmt.Errorf("could not write state file")
+	ErrOnlyLocalStateSupported = fmt.Errorf("only local state is supported")
+)
+
+type localStateManager struct {
+	path   string
+	id     uuid.UUID
+	ctx    context.Context
+	closer context.CancelFunc
+}
+
+func NewLocalStateManager(statePath string, id uuid.UUID) definitions.StateManager {
+	ctx, closer := context.WithCancel(context.Background())
+	// if path does not end with /, add it
+	if statePath[len(statePath)-1] != '/' {
+		statePath = statePath + "/"
+	}
+	return &localStateManager{
+		path:   path.Dir(statePath),
+		id:     id,
+		ctx:    ctx,
+		closer: closer,
+	}
+}
+
+func (s *localStateManager) Reset() error {
+	if s.closer != nil {
+		s.closer()
+	}
+	s.ctx, s.closer = context.WithCancel(context.Background())
+	return nil
+}
+
+func (s *localStateManager) Close() error {
+	if s.closer != nil {
+		s.closer()
+	}
+	return nil
+}
+
+func (s *localStateManager) GetState(stateType definitions.StateType) (map[string]any, error) {
+	if stateType != definitions.StateTypeLocal {
+		return nil, ErrOnlyLocalStateSupported
+	}
+
+	if _, err := os.Stat(s.path); os.IsNotExist(err) {
+		err = os.MkdirAll(s.path, os.ModePerm)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrCouldNotCreateDirectory, err)
+		}
+	}
+
+	fullPath := path.Join(s.path, s.id.String())
+	file, err := os.Open(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: %v", ErrCouldNotOpenFile, err)
+	}
+	fileStat, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCouldNotReadFile, err)
+	}
+	defer file.Close()
+	value := make([]byte, fileStat.Size())
+	_, err = file.Read(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCouldNotReadFile, err)
+	}
+
+	if len(value) == 0 {
+		return nil, nil
+	}
+
+	var state map[string]any
+
+	err = json.Unmarshal(value, &state)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFileCorrupted, err)
+	}
+
+	return state, nil
+}
+
+func (s *localStateManager) SetState(stateType definitions.StateType, value map[string]any) error {
+	if stateType != definitions.StateTypeLocal {
+		return ErrOnlyLocalStateSupported
+	}
+
+	if _, err := os.Stat(s.path); os.IsNotExist(err) {
+		err = os.MkdirAll(s.path, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrCouldNotCreateDirectory, err)
+		}
+	}
+
+	fullPath := path.Join(s.path, s.id.String())
+	file, err := os.Create(fullPath)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrCouldNotOpenFile, err)
+	}
+
+	defer file.Close()
+
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrCouldNotReadFile, err)
+	}
+
+	_, err = file.Write(bytes)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrCouldNotWriteFile, err)
+	}
+
+	return nil
+}
+
+func (s *localStateManager) WatchState(state definitions.StateType, callback func()) error {
+	if state != definitions.StateTypeLocal {
+		return ErrOnlyLocalStateSupported
+	}
+
+	fullPath := path.Join(s.path, s.id.String())
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		err = os.MkdirAll(s.path, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrCouldNotCreateDirectory, err)
+		}
+	}
+
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		file, err := os.Create(fullPath)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrCouldNotOpenFile, err)
+		}
+		file.Close()
+	}
+
+	go s.watchFile(fullPath, callback)
+	return nil
+}
+
+func (s *localStateManager) watchFile(filename string, callback func()) {
+	var lastModTime time.Time
+
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			info, err := os.Stat(filename)
+			if err != nil {
+				logrus.Warnf("Could not stat file: %v", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			if !info.ModTime().Equal(lastModTime) {
+				fmt.Printf("File modified: %s\n", filename)
+				lastModTime = info.ModTime()
+				defer callback()
+				return
+			}
+
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}

--- a/state/local_state_manager_test.go
+++ b/state/local_state_manager_test.go
@@ -1,0 +1,310 @@
+package state
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/google/uuid"
+)
+
+func TestNewLocalStateManager(t *testing.T) {
+	statePath := "./test_state/"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+
+	assert.NotNil(t, manager, "Expected non-nil StateManager")
+
+	lsm, ok := manager.(*localStateManager)
+	assert.True(t, ok, "Expected manager to be of type *localStateManager")
+
+	expectedPath := path.Dir(statePath)
+	assert.True(t, lsm.path == expectedPath, "Expected path %s, got %s", expectedPath, lsm.path)
+
+	assert.True(t, lsm.id == id, "Expected ID %s, got %s", id, lsm.id)
+
+	assert.NotNil(t, lsm.ctx, "Expected non-nil context")
+	assert.NotNil(t, lsm.closer, "Expected non-nil closer")
+}
+
+func TestLocalStateManager_Reset(t *testing.T) {
+	statePath := "./test_state"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	lsm := manager.(*localStateManager)
+
+	err := lsm.Reset()
+	assert.NoError(t, err, "Reset returned an error: ", err)
+
+	select {
+	case <-lsm.ctx.Done():
+		t.Error("Context should not be canceled after reset")
+	default:
+		// Expected path
+	}
+}
+
+func TestLocalStateManager_Close(t *testing.T) {
+	statePath := "./test_state"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	lsm := manager.(*localStateManager)
+
+	err := lsm.Close()
+	assert.NoError(t, err, "Close returned an error: ", err)
+
+	select {
+	case <-lsm.ctx.Done():
+		// Expected path
+	default:
+		t.Error("Context should be canceled after close")
+	}
+}
+
+func TestLocalStateManager_GetSetState(t *testing.T) {
+	statePath := "./test_state_getset"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	// Test SetState
+	stateData := map[string]any{
+		"key1": "value1",
+		"key2": 42,
+	}
+
+	err := manager.SetState(definitions.StateTypeLocal, stateData)
+	assert.NoError(t, err, "SetState returned an error: ", err)
+
+	// Test GetState
+	retrievedState, err := manager.GetState(definitions.StateTypeLocal)
+	assert.NoError(t, err, "GetState returned an error: ", err)
+
+	originalJSON, err := json.Marshal(stateData)
+	assert.NoError(t, err, "Failed to marshal original state: ", err)
+
+	retrievedJSON, err := json.Marshal(retrievedState)
+	assert.NoError(t, err, "Failed to marshal retrieved state: ", err)
+
+	assert.Equal(t, string(originalJSON), string(retrievedJSON))
+
+	// Test GetState when file does not exist
+	err = os.RemoveAll(statePath)
+	assert.NoError(t, err, "Failed to remove state file: ", err)
+	retrievedState, err = manager.GetState(definitions.StateTypeLocal)
+	assert.NoError(t, err, "GetState returned an error: ", err)
+
+	assert.Nil(t, retrievedState, "Expected nil state when file does not exist")
+}
+
+func TestLocalStateManager_WatchState(t *testing.T) {
+	statePath := "./test_state_watch"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	callbackInvoked := false
+	callback := func() {
+		callbackInvoked = true
+		wg.Done()
+	}
+
+	err := manager.WatchState(definitions.StateTypeLocal, callback)
+	assert.NoError(t, err, "WatchState returned an error: ", err)
+
+	// Modify the state file after a short delay
+	go func() {
+		time.Sleep(1 * time.Second)
+		stateData := map[string]any{
+			"updatedKey": "updatedValue",
+		}
+		err := manager.SetState(definitions.StateTypeLocal, stateData)
+		assert.NoError(t, err, "SetState returned an error: ", err)
+	}()
+
+	// Wait for the callback to be invoked
+	waitCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+		// Expected path
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for WatchState callback")
+	}
+
+	if !callbackInvoked {
+		t.Error("Expected callback to be invoked")
+	}
+}
+
+func TestLocalStateManager_Errors(t *testing.T) {
+	statePath := "./test_state_errors"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	// Test SetState with unsupported state type
+	err := manager.SetState(definitions.StateTypeCluster, nil)
+	assert.ErrorIs(t, err, ErrOnlyLocalStateSupported)
+
+	// Test GetState with unsupported state type
+	_, err = manager.GetState(definitions.StateTypeCluster)
+	assert.ErrorIs(t, err, ErrOnlyLocalStateSupported)
+
+	// Test WatchState with unsupported state type
+	err = manager.WatchState(definitions.StateTypeCluster, func() {})
+	assert.ErrorIs(t, err, ErrOnlyLocalStateSupported)
+}
+
+func TestLocalStateManager_CorruptedFile(t *testing.T) {
+	statePath := "./test_state_corrupt/"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	// Create a corrupted state file
+	fullPath := filepath.Join(path.Dir(statePath), id.String())
+	err := os.MkdirAll(path.Dir(fullPath), os.ModePerm)
+	assert.NoError(t, err, "Failed to create directory: ", err)
+
+	file, err := os.Create(fullPath)
+	assert.NoError(t, err, "Failed to create file: ", err)
+
+	_, err = file.Write([]byte("corrupted data"))
+	assert.NoError(t, err, "Failed to write to file: ", err)
+	file.Close()
+
+	// Attempt to GetState
+	_, err = manager.GetState(definitions.StateTypeLocal)
+	if err == nil || err.Error() != ErrFileCorrupted.Error()+": invalid character 'c' looking for beginning of value" {
+		t.Errorf("Expected error starting with %v, got %v", ErrFileCorrupted, err)
+	}
+}
+
+func TestLocalStateManager_ContextCancellation(t *testing.T) {
+	statePath := "./test_state_context"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	lsm := manager.(*localStateManager)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	callbackInvoked := false
+	callback := func() {
+		callbackInvoked = true
+		wg.Done()
+	}
+
+	err := lsm.WatchState(definitions.StateTypeLocal, callback)
+	assert.NoError(t, err, "WatchState returned an error: ", err)
+
+	// Cancel the context to stop the watcher
+	lsm.closer()
+
+	// Wait to ensure watcher has exited
+	time.Sleep(2 * time.Second)
+
+	// Modify the state file
+	stateData := map[string]any{
+		"key": "value",
+	}
+	err = lsm.SetState(definitions.StateTypeLocal, stateData)
+	assert.NoError(t, err, "SetState returned an error: ", err)
+
+	// Callback should not be invoked
+	select {
+	case <-time.After(3 * time.Second):
+		// Expected path
+	}
+
+	assert.False(t, callbackInvoked, "Callback should not be invoked after context cancellation")
+}
+
+func TestLocalStateManager_MultipleWatchers(t *testing.T) {
+	statePath := "./test_state_multiple_watchers"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	callback1Invoked := false
+	callback1 := func() {
+		callback1Invoked = true
+		wg.Done()
+	}
+
+	callback2Invoked := false
+	callback2 := func() {
+		callback2Invoked = true
+		wg.Done()
+	}
+
+	err := manager.WatchState(definitions.StateTypeLocal, callback1)
+	assert.NoError(t, err, "WatchState returned an error: ", err)
+
+	err = manager.WatchState(definitions.StateTypeLocal, callback2)
+	assert.NoError(t, err, "WatchState returned an error: ", err)
+
+	// Modify the state file
+	go func() {
+		time.Sleep(1 * time.Second)
+		stateData := map[string]any{
+			"key": "value",
+		}
+		err := manager.SetState(definitions.StateTypeLocal, stateData)
+		assert.NoError(t, err, "SetState returned an error: ", err)
+	}()
+
+	// Wait for callbacks to be invoked
+	waitCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+		// Expected path
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for WatchState callbacks")
+	}
+
+	assert.False(t, !callback1Invoked || !callback2Invoked, "Expected both callbacks to be invoked")
+}
+
+func TestLocalStateManager_InvalidJSON(t *testing.T) {
+	statePath := "./test_state_invalid_json/"
+	id := uuid.New()
+	manager := NewLocalStateManager(statePath, id)
+	defer os.RemoveAll(statePath)
+
+	// Write invalid JSON to the state file
+	fullPath := filepath.Join(path.Dir(statePath), id.String())
+	err := os.MkdirAll(path.Dir(fullPath), os.ModePerm)
+	assert.NoError(t, err, "Failed to create directory: ", err)
+
+	err = os.WriteFile(fullPath, []byte("{invalid json"), 0644)
+	assert.NoError(t, err, "Failed to write to file: ", err)
+
+	// Attempt to GetState
+	_, err = manager.GetState(definitions.StateTypeLocal)
+	assert.ErrorIs(t, err, ErrFileCorrupted)
+}

--- a/state/multiple_state_types_manager.go
+++ b/state/multiple_state_types_manager.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"errors"
+	"github.com/go-streamline/interfaces/definitions"
+)
+
+var (
+	ErrUnsupportedStateType = errors.New("unsupported state type")
+)
+
+type MultipleStateTypesManager struct {
+	stateManagers map[definitions.StateType]definitions.StateManager
+}
+
+func NewMultipleStateTypesManager(stateManagers map[definitions.StateType]definitions.StateManager) definitions.StateManager {
+	return &MultipleStateTypesManager{
+		stateManagers: stateManagers,
+	}
+}
+
+func (m *MultipleStateTypesManager) Close() error {
+	for _, stateManager := range m.stateManagers {
+		_ = stateManager.Close()
+	}
+	return nil
+}
+
+func (m *MultipleStateTypesManager) Reset() error {
+	for _, stateManager := range m.stateManagers {
+		_ = stateManager.Reset()
+	}
+	return nil
+}
+
+func (m *MultipleStateTypesManager) GetState(stateType definitions.StateType) (map[string]any, error) {
+	stateManager, ok := m.stateManagers[stateType]
+	if !ok {
+		return nil, ErrUnsupportedStateType
+	}
+	return stateManager.GetState(stateType)
+}
+
+func (m *MultipleStateTypesManager) SetState(stateType definitions.StateType, state map[string]any) error {
+	stateManager, ok := m.stateManagers[stateType]
+	if !ok {
+		return ErrUnsupportedStateType
+	}
+	return stateManager.SetState(stateType, state)
+}
+
+func (m *MultipleStateTypesManager) WatchState(state definitions.StateType, callback func()) error {
+	stateManager, ok := m.stateManagers[state]
+	if !ok {
+		return ErrUnsupportedStateType
+	}
+	return stateManager.WatchState(state, callback)
+}
+
+func (m *MultipleStateTypesManager) GetStateManagers() map[definitions.StateType]definitions.StateManager {
+	return m.stateManagers
+}

--- a/state/multiple_state_types_manager_test.go
+++ b/state/multiple_state_types_manager_test.go
@@ -1,0 +1,222 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/go-streamline/core/state"
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockStateManager simulates a StateManager for testing purposes.
+type MockStateManager struct {
+	CloseCalled      bool
+	ResetCalled      bool
+	GetStateCalled   bool
+	SetStateCalled   bool
+	WatchStateCalled bool
+
+	GetStateStateType definitions.StateType
+	SetStateStateType definitions.StateType
+	WatchStateType    definitions.StateType
+
+	SetStateValue map[string]interface{}
+	WatchCallback func()
+
+	GetStateReturnValue map[string]interface{}
+	GetStateError       error
+	SetStateError       error
+	WatchStateError     error
+	CloseError          error
+	ResetError          error
+}
+
+func (m *MockStateManager) Close() error {
+	m.CloseCalled = true
+	return m.CloseError
+}
+
+func (m *MockStateManager) Reset() error {
+	m.ResetCalled = true
+	return m.ResetError
+}
+
+func (m *MockStateManager) GetState(stateType definitions.StateType) (map[string]interface{}, error) {
+	m.GetStateCalled = true
+	m.GetStateStateType = stateType
+	return m.GetStateReturnValue, m.GetStateError
+}
+
+func (m *MockStateManager) SetState(stateType definitions.StateType, state map[string]interface{}) error {
+	m.SetStateCalled = true
+	m.SetStateStateType = stateType
+	m.SetStateValue = state
+	return m.SetStateError
+}
+
+func (m *MockStateManager) WatchState(state definitions.StateType, callback func()) error {
+	m.WatchStateCalled = true
+	m.WatchStateType = state
+	m.WatchCallback = callback
+	return m.WatchStateError
+}
+
+func TestMultipleStateTypesManager_GetState(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Set return values for mock managers
+	mockManager1.GetStateReturnValue = map[string]interface{}{"key": "value1"}
+	mockManager2.GetStateReturnValue = map[string]interface{}{"key": "value2"}
+
+	// Test GetState for StateType1
+	stateValue, err := manager.GetState("StateType1")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"key": "value1"}, stateValue)
+	assert.True(t, mockManager1.GetStateCalled)
+	assert.Equal(t, definitions.StateType("StateType1"), mockManager1.GetStateStateType)
+
+	// Test GetState for StateType2
+	stateValue, err = manager.GetState("StateType2")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"key": "value2"}, stateValue)
+	assert.True(t, mockManager2.GetStateCalled)
+	assert.Equal(t, definitions.StateType("StateType2"), mockManager2.GetStateStateType)
+
+	// Test GetState for unsupported StateType
+	stateValue, err = manager.GetState("UnsupportedStateType")
+	assert.Nil(t, stateValue)
+	assert.ErrorIs(t, err, state.ErrUnsupportedStateType)
+}
+
+func TestMultipleStateTypesManager_SetState(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Test SetState for StateType1
+	err := manager.SetState("StateType1", map[string]interface{}{"key": "value1"})
+	assert.NoError(t, err)
+	assert.True(t, mockManager1.SetStateCalled)
+	assert.Equal(t, definitions.StateType("StateType1"), mockManager1.SetStateStateType)
+	assert.Equal(t, map[string]interface{}{"key": "value1"}, mockManager1.SetStateValue)
+
+	// Test SetState for StateType2
+	err = manager.SetState("StateType2", map[string]interface{}{"key": "value2"})
+	assert.NoError(t, err)
+	assert.True(t, mockManager2.SetStateCalled)
+	assert.Equal(t, definitions.StateType("StateType2"), mockManager2.SetStateStateType)
+	assert.Equal(t, map[string]interface{}{"key": "value2"}, mockManager2.SetStateValue)
+
+	// Test SetState for unsupported StateType
+	err = manager.SetState("UnsupportedStateType", map[string]interface{}{"key": "value"})
+	assert.ErrorIs(t, err, state.ErrUnsupportedStateType)
+}
+
+func TestMultipleStateTypesManager_WatchState(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Prepare a callback function
+	callback := func() {}
+
+	// Test WatchState for StateType1
+	err := manager.WatchState("StateType1", callback)
+	assert.NoError(t, err)
+	assert.True(t, mockManager1.WatchStateCalled)
+	assert.Equal(t, definitions.StateType("StateType1"), mockManager1.WatchStateType)
+
+	// Test WatchState for StateType2
+	err = manager.WatchState("StateType2", callback)
+	assert.NoError(t, err)
+	assert.True(t, mockManager2.WatchStateCalled)
+	assert.Equal(t, definitions.StateType("StateType2"), mockManager2.WatchStateType)
+
+	// Test WatchState for unsupported StateType
+	err = manager.WatchState("UnsupportedStateType", callback)
+	assert.ErrorIs(t, err, state.ErrUnsupportedStateType)
+}
+
+func TestMultipleStateTypesManager_Close(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+	mockManager3 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+		definitions.StateType("StateType3"): mockManager3,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Test Close
+	err := manager.Close()
+	assert.NoError(t, err)
+	assert.True(t, mockManager1.CloseCalled)
+	assert.True(t, mockManager2.CloseCalled)
+	assert.True(t, mockManager3.CloseCalled)
+}
+
+func TestMultipleStateTypesManager_Reset(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+	mockManager3 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+		definitions.StateType("StateType3"): mockManager3,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Test Reset
+	err := manager.Reset()
+	assert.NoError(t, err)
+	assert.True(t, mockManager1.ResetCalled)
+	assert.True(t, mockManager2.ResetCalled)
+	assert.True(t, mockManager3.ResetCalled)
+}
+
+func TestMultipleStateTypesManager_GetStateManagers(t *testing.T) {
+	// Create mock state managers
+	mockManager1 := &MockStateManager{}
+	mockManager2 := &MockStateManager{}
+
+	stateManagers := map[definitions.StateType]definitions.StateManager{
+		definitions.StateType("StateType1"): mockManager1,
+		definitions.StateType("StateType2"): mockManager2,
+	}
+
+	manager := state.NewMultipleStateTypesManager(stateManagers)
+
+	// Test GetStateManagers
+	returnedManagers := manager.(*state.MultipleStateTypesManager).GetStateManagers()
+	assert.Equal(t, stateManagers, returnedManagers)
+}

--- a/state/state_manager_factory.go
+++ b/state/state_manager_factory.go
@@ -1,0 +1,29 @@
+package state
+
+import (
+	"github.com/go-streamline/core/zookeeper"
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/go-zookeeper/zk"
+	"github.com/google/uuid"
+)
+
+type stateManagerFactory struct {
+	zkClient       *zk.Conn
+	localStatePath string
+	zookeeperPath  string
+}
+
+func NewStateManagerFactory(zkClient *zk.Conn, localStatePath string, zookeeperPath string) definitions.StateManagerFactory {
+	return &stateManagerFactory{
+		zkClient:       zkClient,
+		localStatePath: localStatePath,
+		zookeeperPath:  zookeeperPath,
+	}
+}
+
+func (f *stateManagerFactory) CreateStateManager(id uuid.UUID) definitions.StateManager {
+	return NewMultipleStateTypesManager(map[definitions.StateType]definitions.StateManager{
+		definitions.StateTypeLocal:   NewLocalStateManager(f.localStatePath, id),
+		definitions.StateTypeCluster: zookeeper.NewStateManager(f.zkClient, f.zookeeperPath, id),
+	})
+}

--- a/zookeeper/state_manager.go
+++ b/zookeeper/state_manager.go
@@ -1,0 +1,150 @@
+package zookeeper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/go-zookeeper/zk"
+	"github.com/google/uuid"
+	"path"
+)
+
+var (
+	ErrCouldNotCreatePath     = fmt.Errorf("could not create path")
+	ErrCouldNotUnmarshalState = fmt.Errorf("could not unmarshal state")
+	ErrCouldNotMarshalState   = fmt.Errorf("could not marshal state")
+	ErrCouldNotSaveState      = fmt.Errorf("could not save state")
+	ErrUnsupportedStateType   = fmt.Errorf("only CLUSTER and LOCAL state types are supported")
+	ErrFailedToWatchStatePath = fmt.Errorf("failed to watch state path in zookeeper")
+)
+
+type stateManager struct {
+	zkConnection localStateManagerZookeeper
+	zkPath       string
+	ctx          context.Context
+	closer       context.CancelFunc
+}
+
+type localStateManagerZookeeper interface {
+	zkCreateFullPathInterface
+	Get(path string) ([]byte, *zk.Stat, error)
+	Set(path string, data []byte, version int32) (*zk.Stat, error)
+	GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error)
+}
+
+func NewStateManager(
+	zkConnection localStateManagerZookeeper,
+	zkPath string,
+	id uuid.UUID,
+) definitions.StateManager {
+	ctx, closer := context.WithCancel(context.Background())
+	return &stateManager{
+		zkConnection: zkConnection,
+		zkPath:       path.Dir(path.Join(zkPath, id.String()) + "/"),
+		ctx:          ctx,
+		closer:       closer,
+	}
+}
+
+func (s *stateManager) Close() error {
+	if s.closer != nil {
+		s.closer()
+	}
+	return nil
+}
+
+func (s *stateManager) Reset() error {
+	if s.closer != nil {
+		s.closer()
+	}
+	s.ctx, s.closer = context.WithCancel(context.Background())
+	return nil
+}
+
+func (s *stateManager) GetState(stateType definitions.StateType) (map[string]any, error) {
+	if stateType == definitions.StateTypeCluster {
+		err := s.validatePathExists()
+		if err != nil {
+			return nil, err
+		}
+
+		data, _, err := s.zkConnection.Get(s.zkPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(data) == 0 {
+			return nil, nil
+		}
+
+		var value map[string]any
+		err = json.Unmarshal(data, &value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrCouldNotUnmarshalState, err)
+		}
+
+		return value, nil
+	} else {
+		return nil, ErrUnsupportedStateType
+	}
+}
+
+func (s *stateManager) SetState(stateType definitions.StateType, value map[string]any) error {
+	if stateType == definitions.StateTypeCluster {
+
+		err := s.validatePathExists()
+		if err != nil {
+			return err
+		}
+
+		data, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrCouldNotMarshalState, err)
+		}
+
+		_, err = s.zkConnection.Set(s.zkPath, data, -1)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrCouldNotSaveState, err)
+		}
+
+		return nil
+	} else {
+		return ErrUnsupportedStateType
+	}
+}
+
+func (s *stateManager) WatchState(stateType definitions.StateType, callback func()) error {
+	if stateType == definitions.StateTypeCluster {
+		err := s.validatePathExists()
+		if err != nil {
+			return err
+		}
+
+		_, _, ch, err := s.zkConnection.GetW(s.zkPath)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrFailedToWatchStatePath, err)
+		}
+
+		go func() {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-ch:
+				callback()
+			}
+		}()
+		return nil
+	} else {
+		return ErrUnsupportedStateType
+	}
+}
+
+func (s *stateManager) validatePathExists() error {
+	_, _, err := CreateFullPath(s.zkConnection, s.zkPath, []byte{}, zk.FlagPersistent)
+	if err != nil && !errors.Is(err, zk.ErrNodeExists) {
+		return fmt.Errorf("%w: %v", ErrCouldNotCreatePath, err)
+	}
+	return nil
+}

--- a/zookeeper/state_manager_test.go
+++ b/zookeeper/state_manager_test.go
@@ -1,0 +1,342 @@
+package zookeeper
+
+import (
+	"encoding/json"
+	"errors"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-streamline/interfaces/definitions"
+	"github.com/go-zookeeper/zk"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockZKConnection simulates a Zookeeper connection for testing purposes.
+type MockZKConnection struct {
+	data        map[string][]byte
+	existsMap   map[string]bool
+	watchChans  map[string]chan zk.Event
+	mu          sync.Mutex
+	createError error
+	setError    error
+	getError    error
+	getWError   error
+	existsError error
+}
+
+// NewMockZKConnection initializes a new MockZKConnection.
+func NewMockZKConnection() *MockZKConnection {
+	return &MockZKConnection{
+		data:       make(map[string][]byte),
+		existsMap:  make(map[string]bool),
+		watchChans: make(map[string]chan zk.Event),
+	}
+}
+
+func (m *MockZKConnection) Exists(path string) (bool, *zk.Stat, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.existsError != nil {
+		return false, nil, m.existsError
+	}
+	exists, ok := m.existsMap[path]
+	if !ok {
+		return false, nil, nil
+	}
+	return exists, &zk.Stat{}, nil
+}
+
+func (m *MockZKConnection) Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createError != nil {
+		return "", m.createError
+	}
+	if _, exists := m.existsMap[path]; exists {
+		return "", zk.ErrNodeExists
+	}
+	m.existsMap[path] = true
+	m.data[path] = data
+	return path, nil
+}
+
+func (m *MockZKConnection) Get(path string) ([]byte, *zk.Stat, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getError != nil {
+		return nil, nil, m.getError
+	}
+	data, exists := m.data[path]
+	if !exists {
+		return nil, nil, zk.ErrNoNode
+	}
+	return data, &zk.Stat{}, nil
+}
+
+func (m *MockZKConnection) Set(path string, data []byte, version int32) (*zk.Stat, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.setError != nil {
+		return nil, m.setError
+	}
+	if _, exists := m.existsMap[path]; !exists {
+		return nil, zk.ErrNoNode
+	}
+	m.data[path] = data
+
+	// Trigger watch event if there's a watcher on this path
+	if ch, ok := m.watchChans[path]; ok {
+		ch <- zk.Event{Type: zk.EventNodeDataChanged, Path: path}
+	}
+
+	return &zk.Stat{}, nil
+}
+
+func (m *MockZKConnection) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getWError != nil {
+		return nil, nil, nil, m.getWError
+	}
+	data, exists := m.data[path]
+	if !exists {
+		return nil, nil, nil, zk.ErrNoNode
+	}
+	ch := make(chan zk.Event, 1)
+	m.watchChans[path] = ch
+	return data, &zk.Stat{}, ch, nil
+}
+
+// Adjusted Tests
+
+func TestNewStateManager(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	assert.NotNil(t, manager, "Expected non-nil StateManager")
+
+	sm, ok := manager.(*stateManager)
+	assert.True(t, ok, "Expected manager to be of type *stateManager")
+
+	expectedZkPath := path.Dir(path.Join(zkPath, id.String()) + "/")
+	assert.Equal(t, expectedZkPath, sm.zkPath, "Expected zkPath to be %s, got %s", expectedZkPath, sm.zkPath)
+
+	assert.Equal(t, mockZkConn, sm.zkConnection, "Expected zkConnection to be the mockZkConn")
+
+	assert.NotNil(t, sm.ctx, "Expected non-nil context")
+	assert.NotNil(t, sm.closer, "Expected non-nil closer")
+}
+
+func TestStateManager_GetSetState_Cluster(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	sm := manager.(*stateManager)
+
+	// Set state in cluster
+	stateData := map[string]interface{}{
+		"clusterKey": "clusterValue",
+	}
+
+	err := manager.SetState(definitions.StateTypeCluster, stateData)
+	assert.NoError(t, err, "SetState returned an error")
+
+	// Check that data is stored in mockZkConn
+	dataBytes, ok := mockZkConn.data[sm.zkPath]
+	assert.True(t, ok, "Expected data at path %s", sm.zkPath)
+
+	var retrievedState map[string]interface{}
+	err = json.Unmarshal(dataBytes, &retrievedState)
+	assert.NoError(t, err, "Failed to unmarshal data from mockZkConn")
+
+	assert.Equal(t, stateData, retrievedState, "Expected retrieved state to match stateData")
+
+	// Get state from cluster
+	retrievedState, err = manager.GetState(definitions.StateTypeCluster)
+	assert.NoError(t, err, "GetState returned an error")
+
+	assert.Equal(t, stateData, retrievedState, "Expected retrieved state to match stateData")
+}
+
+func TestStateManager_WatchState_Cluster(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	callbackInvoked := false
+	callback := func() {
+		callbackInvoked = true
+		wg.Done()
+	}
+
+	err := manager.WatchState(definitions.StateTypeCluster, callback)
+	assert.NoError(t, err, "WatchState returned an error")
+
+	// Modify the cluster state after a short delay
+	go func() {
+		time.Sleep(1 * time.Second)
+		stateData := map[string]interface{}{
+			"clusterKey": "newValue",
+		}
+		err := manager.SetState(definitions.StateTypeCluster, stateData)
+		assert.NoError(t, err, "SetState returned an error")
+	}()
+
+	// Wait for the callback to be invoked
+	waitCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+		// Expected
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for WatchState callback")
+	}
+
+	assert.True(t, callbackInvoked, "Expected callback to be invoked")
+}
+
+func TestStateManager_Errors(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	// Test unsupported state type
+	err := manager.SetState("Unknown", nil)
+	assert.ErrorIs(t, err, ErrUnsupportedStateType, "Expected ErrUnsupportedStateType")
+
+	_, err = manager.GetState("Unknown")
+	assert.ErrorIs(t, err, ErrUnsupportedStateType, "Expected ErrUnsupportedStateType")
+
+	err = manager.WatchState("Unknown", func() {})
+	assert.ErrorIs(t, err, ErrUnsupportedStateType, "Expected ErrUnsupportedStateType")
+}
+
+func TestStateManager_CorruptedClusterState(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	sm := manager.(*stateManager)
+
+	// Simulate corrupted data in Zookeeper
+	mockZkConn.data[sm.zkPath] = []byte("corrupted data")
+	mockZkConn.existsMap[sm.zkPath] = true
+
+	_, err := manager.GetState(definitions.StateTypeCluster)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), ErrCouldNotUnmarshalState.Error(), "Expected ErrCouldNotUnmarshalState")
+}
+
+func TestStateManager_validatePathExists(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/validate/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	sm := manager.(*stateManager)
+
+	err := sm.validatePathExists()
+	assert.NoError(t, err, "validatePathExists returned an error")
+
+	// Verify that the path exists in mockZkConn
+	parts := splitPath(sm.zkPath)
+	currentPath := ""
+	for _, part := range parts {
+		currentPath += "/" + part
+		exists, _, err := mockZkConn.Exists(currentPath)
+		assert.NoError(t, err, "Exists returned an error")
+		assert.True(t, exists, "Expected path %s to exist", currentPath)
+	}
+}
+
+func TestStateManager_validatePathExists_Error(t *testing.T) {
+	// Create a mock zkConnection that returns an error on Create
+	mockZkConn := NewMockZKConnection()
+	mockZkConn.createError = errors.New("mock create error")
+
+	zkPath := "/test/validate/error"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	sm := manager.(*stateManager)
+
+	err := sm.validatePathExists()
+	assert.Error(t, err, "Expected error from validatePathExists")
+	assert.Contains(t, err.Error(), ErrCouldNotCreatePath.Error(), "Expected ErrCouldNotCreatePath")
+}
+
+func TestStateManager_ContextCancellation(t *testing.T) {
+	mockZkConn := NewMockZKConnection()
+
+	zkPath := "/test/path"
+	id := uuid.New()
+
+	manager := NewStateManager(mockZkConn, zkPath, id)
+
+	sm := manager.(*stateManager)
+
+	callbackCh := make(chan struct{}, 1)
+
+	callbackInvoked := false
+	callback := func() {
+		callbackInvoked = true
+		callbackCh <- struct{}{}
+	}
+
+	err := manager.WatchState(definitions.StateTypeCluster, callback)
+	assert.NoError(t, err, "WatchState returned an error")
+
+	// Cancel the context
+	sm.closer()
+
+	// Modify the cluster state after a short delay
+	go func() {
+		time.Sleep(1 * time.Second)
+		stateData := map[string]interface{}{
+			"clusterKey": "newValue",
+		}
+		err := manager.SetState(definitions.StateTypeCluster, stateData)
+		assert.NoError(t, err, "SetState returned an error")
+	}()
+
+	// Wait for a short time to ensure callback is not invoked
+	select {
+	case <-time.After(3 * time.Second):
+		// Expected
+	case <-callbackCh:
+		// Callback invoked, which is not expected
+		t.Error("Callback should not be invoked after context cancellation")
+	}
+
+	assert.False(t, callbackInvoked, "Callback should not be invoked after context cancellation")
+}

--- a/zookeeper/utils.go
+++ b/zookeeper/utils.go
@@ -7,10 +7,15 @@ import (
 	"strings"
 )
 
+type zkCreateFullPathInterface interface {
+	Exists(path string) (bool, *zk.Stat, error)
+	Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error)
+}
+
 // CreateFullPath creates a path in Zookeeper and all its parent nodes if they do not exist.
 // If data is nil, the hostname of the current machine is used as the data.
 // Returns the created path and the data as a string.
-func CreateFullPath(conn *zk.Conn, path string, data []byte, flags int32) (string, string, error) {
+func CreateFullPath(conn zkCreateFullPathInterface, path string, data []byte, flags int32) (string, string, error) {
 	parts := splitPath(path)
 	// drop last part
 	parts = parts[:len(parts)-1]


### PR DESCRIPTION
## Description
Added state management support including:
* local state manager for each node to store in
* zookeeper state manager to manage state over a cluster
* multiple state manager to be able to handle both local and cluster state types using other state managers
* state management factory

## Tests
Added unit tests and of course tested it using this Dockerfile:
```Dockerfile
FROM golang:1.23.2-alpine3.20 AS builder

WORKDIR /app
COPY . .
RUN go mod tidy
RUN go build -o /app/main .


FROM alpine:3.13
COPY --from=builder /app/main /app/main
CMD ["/app/main", "zookeeper:2181"]

LABEL version="latest"
```

this docker-compose:
```yaml
version: '3'
services:
  zookeeper:
    image: zookeeper:3.7.2
    ports:
      - "2181:2181"
    container_name: zookeeper
    environment:
        ZOO_MY_ID: 1
        ZOO_SERVERS: server.1=zookeeper:2888:3888;2181

  core0:
    image: core:latest
    container_name: core0

  core1:
    image: core:latest
    container_name: core1

  core2:
    image: core:latest
    container_name: core2
  core3:
    image: core:latest
    container_name: core3
```

and these as code:
```go
package main

import (
	"github.com/go-streamline/core/state"
	"github.com/go-streamline/interfaces/definitions"
	"github.com/google/uuid"
	"github.com/sirupsen/logrus"
	"os"
	"os/signal"
)

func main() {
	stateManager := state.NewLocalStateManager("/tmp/localstate", uuid.MustParse(uuids[0]))
	logrus.Infof("State changed")
	m, err := stateManager.GetState(definitions.StateTypeLocal)
	if err != nil {
		logrus.Errorf("Error getting state: %v", err)
	}

	logrus.Infof("State: %v", m)

	signals := make(chan os.Signal, 1)
	signal.Notify(signals, os.Interrupt)
	<-signals

}
```


```go
package main

import (
	"context"
	"github.com/go-streamline/core/zookeeper"
	"github.com/go-streamline/interfaces/definitions"
	"github.com/go-zookeeper/zk"
	"github.com/google/uuid"
	"github.com/sirupsen/logrus"
	"os"
	"os/signal"
	"time"
)

var uuids = []string{
	"8670d592-756b-49bd-bd7c-2ff8fdd5305c",
	"2968e141-8175-466f-a08c-fc11b4e2c492",
	"fcabe1a2-270f-4866-9046-005a3c090c69",
	"6487e965-ac10-4807-903f-cd81af40b222",
	"c77f4f39-e57c-4489-9b96-bed1a8b7992f",
	"8ca53bb2-40b6-4994-ba20-5078969d41d2",
	"dda612d0-9ecd-45a6-976a-cddde1e58ddc",
	"15259a5a-3b86-4e03-b39e-02ba01e6cc6a",
	"85d4989f-e39f-4286-ac6c-ac096b77f818",
	"9e4e17d7-7c78-4523-b2f9-2cedda4a7778",
}

type HostHook struct {
	Hostname string
	Context  string
}

func (hook *HostHook) Levels() []logrus.Level {
	return logrus.AllLevels
}

func (hook *HostHook) Fire(entry *logrus.Entry) error {
	entry.Data["host"] = hook.Hostname
	entry.Data["context"] = hook.Context
	return nil
}

func main() {

	s := os.Args[1]
	logrus.Infof("Connecting to %s", s)
	conn, _, err := zk.Connect([]string{s}, 10*time.Second)
	if err != nil {
		panic(err)
	}
	hostname, err := os.Hostname()
	if err != nil {
		panic(err)
	}
	zkLogger := logrus.New()
	zkLogger.AddHook(&HostHook{Hostname: hostname, Context: "zkLeader"})
	leader := zookeeper.NewZookeeperLeaderSelector(conn, "/whatever/nodes", zkLogger, "myleader_")
	leader.Start()

	time.Sleep(2 * time.Second)
	nodes, err := leader.Participants()
	if err != nil {
		logrus.Errorf("Error getting nodes: %v", err)
	}
	logrus.Infof("nodes: %s", nodes)

	ctx, cancel := context.WithCancel(context.Background())

	zkLogger = logrus.New()
	zkLogger.AddHook(&HostHook{Hostname: hostname, Context: "zkCoordinator"})
	coordinator := zookeeper.NewCoordinator(leader, conn, "/whatever/aaaa/", zkLogger)
	stateManager := zookeeper.NewStateManager(conn, "/states/", uuid.MustParse(uuids[0]))
	err = stateManager.WatchState(definitions.StateTypeCluster, func() {
		logrus.Infof("State changed")
		m, err := stateManager.GetState(definitions.StateTypeCluster)
		if err != nil {
			logrus.Errorf("Error getting state: %v", err)
		}

		logrus.Infof("State: %v", m)
	})

	if err != nil {
		logrus.Errorf("Error watching state: %v", err)
	}
	logrus.AddHook(&HostHook{Hostname: hostname, Context: "main"})
	go func() {
		t := time.NewTicker(5 * time.Second)
		var stateMap = make(map[string]any)
		for {
			select {
			case <-t.C:
				isLeader1, err := leader.IsLeader()
				if err != nil {
					logrus.WithField("host", hostname).Errorf("Error checking if leader: %v", err)
					continue
				}
				logrus.Infof("Is leader: %v", isLeader1)

				for _, u := range uuids {
					isLeader, err := coordinator.IsLeader(uuid.MustParse(u))
					if err != nil {
						logrus.Errorf("Error checking if tp is leader: %v", err)
						continue
					}

					stateMap[u] = isLeader
					logrus.Infof("Is leader for %s: %v", u, isLeader)
				}

				if isLeader1 {
					err = stateManager.SetState(definitions.StateTypeCluster, stateMap)
					if err != nil {
						logrus.Errorf("Error setting state: %v", err)
					}
				}

			case <-ctx.Done():
				t.Stop()
				return
			}
		}
	}()

	signals := make(chan os.Signal, 1)
	signal.Notify(signals, os.Interrupt)
	<-signals
	cancel()

}
```